### PR TITLE
Reorganize the directory structure

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
-.vagrant/*
+**/.vagrant/*
 *.log
 tmp/*
 

--- a/script/vagrant/sloopstash-centos-server/destroy
+++ b/script/vagrant/sloopstash-centos-server/destroy
@@ -1,3 +1,0 @@
-#!/bin/bash
-
-VAGRANT_DISABLE_VBOXSYMLINKCREATE=1 VAGRANT_VAGRANTFILE=vagrant/sloopstash-centos-server.vagrantfile vagrant destroy sloopstash-centos-server

--- a/script/vagrant/sloopstash-centos-server/halt
+++ b/script/vagrant/sloopstash-centos-server/halt
@@ -1,3 +1,0 @@
-#!/bin/bash
-
-VAGRANT_DISABLE_VBOXSYMLINKCREATE=1 VAGRANT_VAGRANTFILE=vagrant/sloopstash-centos-server.vagrantfile vagrant halt

--- a/script/vagrant/sloopstash-centos-server/provision
+++ b/script/vagrant/sloopstash-centos-server/provision
@@ -1,3 +1,0 @@
-#!/bin/bash
-
-VAGRANT_DISABLE_VBOXSYMLINKCREATE=1 VAGRANT_VAGRANTFILE=vagrant/sloopstash-centos-server.vagrantfile vagrant provision

--- a/script/vagrant/sloopstash-centos-server/ssh
+++ b/script/vagrant/sloopstash-centos-server/ssh
@@ -1,3 +1,0 @@
-#!/bin/bash
-
-VAGRANT_DISABLE_VBOXSYMLINKCREATE=1 VAGRANT_VAGRANTFILE=vagrant/sloopstash-centos-server.vagrantfile vagrant ssh

--- a/script/vagrant/sloopstash-centos-server/up
+++ b/script/vagrant/sloopstash-centos-server/up
@@ -1,3 +1,0 @@
-#!/bin/bash
-
-VAGRANT_DISABLE_VBOXSYMLINKCREATE=1 VAGRANT_VAGRANTFILE=vagrant/sloopstash-centos-server.vagrantfile vagrant up --provider=virtualbox

--- a/script/vagrant/sloopstash-ubuntu-desktop/destroy
+++ b/script/vagrant/sloopstash-ubuntu-desktop/destroy
@@ -1,3 +1,0 @@
-#!/bin/bash
-
-VAGRANT_DISABLE_VBOXSYMLINKCREATE=1 VAGRANT_VAGRANTFILE=vagrant/sloopstash-ubuntu-desktop.vagrantfile vagrant destroy sloopstash-ubuntu-desktop

--- a/script/vagrant/sloopstash-ubuntu-desktop/halt
+++ b/script/vagrant/sloopstash-ubuntu-desktop/halt
@@ -1,3 +1,0 @@
-#!/bin/bash
-
-VAGRANT_DISABLE_VBOXSYMLINKCREATE=1 VAGRANT_VAGRANTFILE=vagrant/sloopstash-ubuntu-desktop.vagrantfile vagrant halt

--- a/script/vagrant/sloopstash-ubuntu-desktop/provision
+++ b/script/vagrant/sloopstash-ubuntu-desktop/provision
@@ -1,3 +1,0 @@
-#!/bin/bash
-
-VAGRANT_DISABLE_VBOXSYMLINKCREATE=1 VAGRANT_VAGRANTFILE=vagrant/sloopstash-ubuntu-desktop.vagrantfile vagrant provision

--- a/script/vagrant/sloopstash-ubuntu-desktop/ssh
+++ b/script/vagrant/sloopstash-ubuntu-desktop/ssh
@@ -1,3 +1,0 @@
-#!/bin/bash
-
-VAGRANT_DISABLE_VBOXSYMLINKCREATE=1 VAGRANT_VAGRANTFILE=vagrant/sloopstash-ubuntu-desktop.vagrantfile vagrant ssh

--- a/script/vagrant/sloopstash-ubuntu-desktop/up
+++ b/script/vagrant/sloopstash-ubuntu-desktop/up
@@ -1,3 +1,0 @@
-#!/bin/bash
-
-VAGRANT_DISABLE_VBOXSYMLINKCREATE=1 VAGRANT_VAGRANTFILE=vagrant/sloopstash-ubuntu-desktop.vagrantfile vagrant up --provider=virtualbox

--- a/script/vagrant/sloopstash-ubuntu-server/destroy
+++ b/script/vagrant/sloopstash-ubuntu-server/destroy
@@ -1,3 +1,0 @@
-#!/bin/bash
-
-VAGRANT_DISABLE_VBOXSYMLINKCREATE=1 VAGRANT_VAGRANTFILE=vagrant/sloopstash-ubuntu-server.vagrantfile vagrant destroy sloopstash-ubuntu-server

--- a/script/vagrant/sloopstash-ubuntu-server/halt
+++ b/script/vagrant/sloopstash-ubuntu-server/halt
@@ -1,3 +1,0 @@
-#!/bin/bash
-
-VAGRANT_DISABLE_VBOXSYMLINKCREATE=1 VAGRANT_VAGRANTFILE=vagrant/sloopstash-ubuntu-server.vagrantfile vagrant halt

--- a/script/vagrant/sloopstash-ubuntu-server/provision
+++ b/script/vagrant/sloopstash-ubuntu-server/provision
@@ -1,3 +1,0 @@
-#!/bin/bash
-
-VAGRANT_DISABLE_VBOXSYMLINKCREATE=1 VAGRANT_VAGRANTFILE=vagrant/sloopstash-ubuntu-server.vagrantfile vagrant provision

--- a/script/vagrant/sloopstash-ubuntu-server/ssh
+++ b/script/vagrant/sloopstash-ubuntu-server/ssh
@@ -1,3 +1,0 @@
-#!/bin/bash
-
-VAGRANT_DISABLE_VBOXSYMLINKCREATE=1 VAGRANT_VAGRANTFILE=vagrant/sloopstash-ubuntu-server.vagrantfile vagrant ssh

--- a/script/vagrant/sloopstash-ubuntu-server/up
+++ b/script/vagrant/sloopstash-ubuntu-server/up
@@ -1,3 +1,0 @@
-#!/bin/bash
-
-VAGRANT_DISABLE_VBOXSYMLINKCREATE=1 VAGRANT_VAGRANTFILE=vagrant/sloopstash-ubuntu-server.vagrantfile vagrant up --provider=virtualbox

--- a/vagrant/centos-7-server/virtualbox/amd64/Vagrantfile
+++ b/vagrant/centos-7-server/virtualbox/amd64/Vagrantfile
@@ -1,0 +1,92 @@
+# -*- mode: ruby -*-
+# vi: set ft=ruby :
+
+# All Vagrant configuration is done below. The "2" in Vagrant.configure
+# configures the configuration version (we support older styles for
+# backwards compatibility). Please don't change it unless you know what
+# you're doing.
+Vagrant.configure("2") do |config|
+  # The most common configuration options are documented and commented below.
+  # For a complete reference, please see the online documentation at
+  # https://docs.vagrantup.com.
+
+  # Every Vagrant development environment requires a box. You can search for
+  # boxes at https://vagrantcloud.com/search.
+  config.vm.box = "sloopstash/centos-7-server"
+
+  # Define virtual machine name.
+  config.vm.define "sloopstash-centos-7-server"
+
+  # Set virtual machine hostname.
+  config.vm.hostname = "sloopstash-centos-7-server"
+
+  # Disable automatic box update checking. If you disable this, then
+  # boxes will only be checked for updates when the user runs
+  # `vagrant box outdated`. This is not recommended.
+  config.vm.box_check_update = false
+
+  # Create a forwarded port mapping which allows access to a specific port
+  # within the machine from a port on the host machine. In the example below,
+  # accessing "localhost:8080" will access port 80 on the guest machine.
+  # NOTE: This will enable public access to the opened port
+  # config.vm.network "forwarded_port", guest: 443, host: 443, auto_correct: false
+
+  # Create a forwarded port mapping which allows access to a specific port
+  # within the machine from a port on the host machine and only allow access
+  # via 127.0.0.1 to disable public access
+  # config.vm.network "forwarded_port", guest: 80, host: 8080, host_ip: "127.0.0.1"
+
+  # Create a private network, which allows host-only access to the machine
+  # using a specific IP.
+  config.vm.network "private_network", ip: "192.168.1.4"
+
+  # Create a public network, which generally matched to bridged network.
+  # Bridged networks make the machine appear as another physical device on
+  # your network.
+  # config.vm.network "public_network"
+
+  # Share an additional folder to the guest VM. The first argument is
+  # the path on the host to the actual folder. The second argument is
+  # the path on the guest to mount the folder. And the optional third
+  # argument is a set of non-required options.
+  config.vm.synced_folder ".", "/vagrant", disabled: true
+
+  # SSH credentials to connect to virtual machine.
+  config.ssh.username = "vagrant"
+  config.ssh.private_key_path = ["~/.vagrant.d/insecure_private_key"]
+  config.ssh.insert_key = false
+
+  # Provider-specific configuration so you can fine-tune various
+  # backing providers for Vagrant. These expose provider-specific options.
+  # Example for VirtualBox:
+  #
+  config.vm.provider "virtualbox" do |vb|
+    # Enable USB controller for the virtual machine.
+    vb.customize ["modifyvm",:id,"--usb","on"]
+
+    # Disable GUI when booting the virtual machine.
+    vb.gui = false
+  
+    # Allocate memory to the virtual machine.
+    vb.memory = "2048"
+
+    # Allocate processors to the virtual machine.
+    vb.cpus = "1"
+
+    # Set name for the virtual machine.
+    vb.name = "sloopstash-centos-7-server"
+  end
+  #
+  # View the documentation for the provider you are using for more
+  # information on available options.
+
+  # Enable provisioning with a shell script. Additional provisioners such as
+  # Puppet, Chef, Ansible, Salt, and Docker are also available. Please see the
+  # documentation for more information about their specific syntax and use.
+  config.vm.provision "shell", inline: <<-SHELL
+    systemctl stop postfix.service
+    systemctl disable postfix.service
+    yum update -y
+    yum install -y wget vim net-tools initscripts gcc make tar bind-utils nc git unzip sysstat tree
+  SHELL
+end

--- a/vagrant/centos-7-server/vmware/amd64/Vagrantfile
+++ b/vagrant/centos-7-server/vmware/amd64/Vagrantfile
@@ -1,0 +1,86 @@
+# -*- mode: ruby -*-
+# vi: set ft=ruby :
+
+# All Vagrant configuration is done below. The "2" in Vagrant.configure
+# configures the configuration version (we support older styles for
+# backwards compatibility). Please don't change it unless you know what
+# you're doing.
+Vagrant.configure("2") do |config|
+  # The most common configuration options are documented and commented below.
+  # For a complete reference, please see the online documentation at
+  # https://docs.vagrantup.com.
+
+  # Every Vagrant development environment requires a box. You can search for
+  # boxes at https://vagrantcloud.com/search.
+  config.vm.box = "sloopstash/centos-7-server"
+
+  # Define virtual machine name.
+  config.vm.define "sloopstash-centos-7-server"
+
+  # Set virtual machine hostname.
+  config.vm.hostname = "sloopstash-centos-7-server"
+
+  # Disable automatic box update checking. If you disable this, then
+  # boxes will only be checked for updates when the user runs
+  # `vagrant box outdated`. This is not recommended.
+  config.vm.box_check_update = false
+
+  # Create a forwarded port mapping which allows access to a specific port
+  # within the machine from a port on the host machine. In the example below,
+  # accessing "localhost:8080" will access port 80 on the guest machine.
+  # NOTE: This will enable public access to the opened port
+  # config.vm.network "forwarded_port", guest: 443, host: 443, auto_correct: false
+
+  # Create a forwarded port mapping which allows access to a specific port
+  # within the machine from a port on the host machine and only allow access
+  # via 127.0.0.1 to disable public access
+  # config.vm.network "forwarded_port", guest: 80, host: 8080, host_ip: "127.0.0.1"
+
+  # Create a private network, which allows host-only access to the machine
+  # using a specific IP.
+  config.vm.network "private_network", ip: "192.168.2.4"
+
+  # Create a public network, which generally matched to bridged network.
+  # Bridged networks make the machine appear as another physical device on
+  # your network.
+  # config.vm.network "public_network"
+
+  # Share an additional folder to the guest VM. The first argument is
+  # the path on the host to the actual folder. The second argument is
+  # the path on the guest to mount the folder. And the optional third
+  # argument is a set of non-required options.
+  config.vm.synced_folder ".", "/vagrant", disabled: true
+
+  # SSH credentials to connect to virtual machine.
+  config.ssh.username = "vagrant"
+  config.ssh.private_key_path = ["~/.vagrant.d/insecure_private_key"]
+  config.ssh.insert_key = false
+
+  # Provider-specific configuration so you can fine-tune various
+  # backing providers for Vagrant. These expose provider-specific options.
+  # Example for VirtualBox:
+  #
+  config.vm.provider "vmware_fusion" do |vb|
+    # Disable GUI when booting the virtual machine.
+    vb.gui = false
+  
+    # Allocate memory to the virtual machine.
+    vb.memory = "2048"
+
+    # Allocate processors to the virtual machine.
+    vb.cpus = "1"
+  end
+  #
+  # View the documentation for the provider you are using for more
+  # information on available options.
+
+  # Enable provisioning with a shell script. Additional provisioners such as
+  # Puppet, Chef, Ansible, Salt, and Docker are also available. Please see the
+  # documentation for more information about their specific syntax and use.
+  config.vm.provision "shell", inline: <<-SHELL
+    systemctl stop postfix.service
+    systemctl disable postfix.service
+    yum update -y
+    yum install -y wget vim net-tools initscripts gcc make tar bind-utils nc git unzip sysstat tree
+  SHELL
+end

--- a/vagrant/ubuntu-18-04-server/virtualbox/amd64/Vagrantfile
+++ b/vagrant/ubuntu-18-04-server/virtualbox/amd64/Vagrantfile
@@ -12,13 +12,13 @@ Vagrant.configure("2") do |config|
 
   # Every Vagrant development environment requires a box. You can search for
   # boxes at https://vagrantcloud.com/search.
-  config.vm.box = "sloopstash/centos-7-server"
+  config.vm.box = "sloopstash/ubuntu-18-04-server"
 
-  # Define virtual machine name.
-  config.vm.define "sloopstash-centos-server"
+ # Define virtual machine name.
+  config.vm.define "sloopstash-ubuntu-18-04-server"
 
   # Set virtual machine hostname.
-  config.vm.hostname = "sloopstash-centos-server"
+  config.vm.hostname = "sloopstash-ubuntu-18-04-server"
 
   # Disable automatic box update checking. If you disable this, then
   # boxes will only be checked for updates when the user runs
@@ -29,7 +29,7 @@ Vagrant.configure("2") do |config|
   # within the machine from a port on the host machine. In the example below,
   # accessing "localhost:8080" will access port 80 on the guest machine.
   # NOTE: This will enable public access to the opened port
-  #	config.vm.network "forwarded_port", guest: 443, host: 443, auto_correct: false
+  # config.vm.network "forwarded_port", guest: 443, host: 443, auto_correct: false
 
   # Create a forwarded port mapping which allows access to a specific port
   # within the machine from a port on the host machine and only allow access
@@ -38,7 +38,7 @@ Vagrant.configure("2") do |config|
 
   # Create a private network, which allows host-only access to the machine
   # using a specific IP.
-  config.vm.network "private_network", ip: "192.168.99.105"
+  config.vm.network "private_network", ip: "192.168.1.5"
 
   # Create a public network, which generally matched to bridged network.
   # Bridged networks make the machine appear as another physical device on
@@ -74,7 +74,7 @@ Vagrant.configure("2") do |config|
     vb.cpus = "1"
 
     # Set name for the virtual machine.
-    vb.name = "sloopstash-centos-server"
+    vb.name = "sloopstash-ubuntu-18-04-server"
   end
   #
   # View the documentation for the provider you are using for more
@@ -84,9 +84,8 @@ Vagrant.configure("2") do |config|
   # Puppet, Chef, Ansible, Salt, and Docker are also available. Please see the
   # documentation for more information about their specific syntax and use.
   config.vm.provision "shell", inline: <<-SHELL
-    systemctl stop postfix.service
-    systemctl disable postfix.service
-    yum update -y
-    yum install -y wget vim net-tools initscripts gcc make tar bind-utils nc git unzip sysstat tree
+    apt update
+    apt upgrade -y
+    apt install -y wget vim net-tools gcc make tar git unzip sysstat tree
   SHELL
 end

--- a/vagrant/ubuntu-18-04-server/vmware/amd64/Vagrantfile
+++ b/vagrant/ubuntu-18-04-server/vmware/amd64/Vagrantfile
@@ -1,0 +1,85 @@
+# -*- mode: ruby -*-
+# vi: set ft=ruby :
+
+# All Vagrant configuration is done below. The "2" in Vagrant.configure
+# configures the configuration version (we support older styles for
+# backwards compatibility). Please don't change it unless you know what
+# you're doing.
+Vagrant.configure("2") do |config|
+  # The most common configuration options are documented and commented below.
+  # For a complete reference, please see the online documentation at
+  # https://docs.vagrantup.com.
+
+  # Every Vagrant development environment requires a box. You can search for
+  # boxes at https://vagrantcloud.com/search.
+  config.vm.box = "sloopstash/ubuntu-18-04-server"
+
+ # Define virtual machine name.
+  config.vm.define "sloopstash-ubuntu-18-04-server"
+
+  # Set virtual machine hostname.
+  config.vm.hostname = "sloopstash-ubuntu-18-04-server"
+
+  # Disable automatic box update checking. If you disable this, then
+  # boxes will only be checked for updates when the user runs
+  # `vagrant box outdated`. This is not recommended.
+  config.vm.box_check_update = false
+
+  # Create a forwarded port mapping which allows access to a specific port
+  # within the machine from a port on the host machine. In the example below,
+  # accessing "localhost:8080" will access port 80 on the guest machine.
+  # NOTE: This will enable public access to the opened port
+  # config.vm.network "forwarded_port", guest: 443, host: 443, auto_correct: false
+
+  # Create a forwarded port mapping which allows access to a specific port
+  # within the machine from a port on the host machine and only allow access
+  # via 127.0.0.1 to disable public access
+  # config.vm.network "forwarded_port", guest: 80, host: 8080, host_ip: "127.0.0.1"
+
+  # Create a private network, which allows host-only access to the machine
+  # using a specific IP.
+  config.vm.network "private_network", ip: "192.168.2.5"
+
+  # Create a public network, which generally matched to bridged network.
+  # Bridged networks make the machine appear as another physical device on
+  # your network.
+  # config.vm.network "public_network"
+
+  # Share an additional folder to the guest VM. The first argument is
+  # the path on the host to the actual folder. The second argument is
+  # the path on the guest to mount the folder. And the optional third
+  # argument is a set of non-required options.
+  config.vm.synced_folder ".", "/vagrant", disabled: true
+
+  # SSH credentials to connect to virtual machine.
+  config.ssh.username = "vagrant"
+  config.ssh.private_key_path = ["~/.vagrant.d/insecure_private_key"]
+  config.ssh.insert_key = false
+
+  # Provider-specific configuration so you can fine-tune various
+  # backing providers for Vagrant. These expose provider-specific options.
+  # Example for VirtualBox:
+  #
+  config.vm.provider "vmware_fusion" do |vb|
+    # Disable GUI when booting the virtual machine.
+    vb.gui = false
+  
+    # Allocate memory to the virtual machine.
+    vb.memory = "2048"
+
+    # Allocate processors to the virtual machine.
+    vb.cpus = "1"
+  end
+  #
+  # View the documentation for the provider you are using for more
+  # information on available options.
+
+  # Enable provisioning with a shell script. Additional provisioners such as
+  # Puppet, Chef, Ansible, Salt, and Docker are also available. Please see the
+  # documentation for more information about their specific syntax and use.
+  config.vm.provision "shell", inline: <<-SHELL
+    apt update
+    apt upgrade -y
+    apt install -y wget vim net-tools gcc make tar git unzip sysstat tree
+  SHELL
+end

--- a/vagrant/ubuntu-22-04-server/virtualbox/amd64/Vagrantfile
+++ b/vagrant/ubuntu-22-04-server/virtualbox/amd64/Vagrantfile
@@ -12,13 +12,13 @@ Vagrant.configure("2") do |config|
 
   # Every Vagrant development environment requires a box. You can search for
   # boxes at https://vagrantcloud.com/search.
-  config.vm.box = "sloopstash/ubuntu-18-04-server"
+  config.vm.box = "sloopstash/ubuntu-22-04-server"
 
  # Define virtual machine name.
-  config.vm.define "sloopstash-ubuntu-server"
+  config.vm.define "sloopstash-ubuntu-22-04-server"
 
   # Set virtual machine hostname.
-  config.vm.hostname = "sloopstash-ubuntu-server"
+  config.vm.hostname = "sloopstash-ubuntu-22-04-server"
 
   # Disable automatic box update checking. If you disable this, then
   # boxes will only be checked for updates when the user runs
@@ -29,7 +29,7 @@ Vagrant.configure("2") do |config|
   # within the machine from a port on the host machine. In the example below,
   # accessing "localhost:8080" will access port 80 on the guest machine.
   # NOTE: This will enable public access to the opened port
-  #	config.vm.network "forwarded_port", guest: 443, host: 443, auto_correct: false
+  # config.vm.network "forwarded_port", guest: 443, host: 443, auto_correct: false
 
   # Create a forwarded port mapping which allows access to a specific port
   # within the machine from a port on the host machine and only allow access
@@ -38,7 +38,7 @@ Vagrant.configure("2") do |config|
 
   # Create a private network, which allows host-only access to the machine
   # using a specific IP.
-  config.vm.network "private_network", ip: "192.168.99.106"
+  config.vm.network "private_network", ip: "192.168.1.6"
 
   # Create a public network, which generally matched to bridged network.
   # Bridged networks make the machine appear as another physical device on
@@ -74,7 +74,7 @@ Vagrant.configure("2") do |config|
     vb.cpus = "1"
 
     # Set name for the virtual machine.
-    vb.name = "sloopstash-ubuntu-server"
+    vb.name = "sloopstash-ubuntu-22-04-server"
   end
   #
   # View the documentation for the provider you are using for more

--- a/vagrant/ubuntu-22-04-server/vmware/amd64/Vagrantfile
+++ b/vagrant/ubuntu-22-04-server/vmware/amd64/Vagrantfile
@@ -12,13 +12,13 @@ Vagrant.configure("2") do |config|
 
   # Every Vagrant development environment requires a box. You can search for
   # boxes at https://vagrantcloud.com/search.
-  config.vm.box = "peru/ubuntu-18.04-desktop-amd64"
+  config.vm.box = "sloopstash/ubuntu-22-04-server"
 
-  # Define virtual machine name.
-  config.vm.define "sloopstash-ubuntu-desktop"
+ # Define virtual machine name.
+  config.vm.define "sloopstash-ubuntu-22-04-server"
 
   # Set virtual machine hostname.
-  config.vm.hostname = "sloopstash-ubuntu-desktop"
+  config.vm.hostname = "sloopstash-ubuntu-22-04-server"
 
   # Disable automatic box update checking. If you disable this, then
   # boxes will only be checked for updates when the user runs
@@ -38,7 +38,7 @@ Vagrant.configure("2") do |config|
 
   # Create a private network, which allows host-only access to the machine
   # using a specific IP.
-  config.vm.network "private_network", ip: "192.168.99.104"
+  config.vm.network "private_network", ip: "192.168.2.6"
 
   # Create a public network, which generally matched to bridged network.
   # Bridged networks make the machine appear as another physical device on
@@ -60,21 +60,15 @@ Vagrant.configure("2") do |config|
   # backing providers for Vagrant. These expose provider-specific options.
   # Example for VirtualBox:
   #
-  config.vm.provider "virtualbox" do |vb|
-    # Enable USB controller for the virtual machine.
-    vb.customize ["modifyvm",:id,"--usb","on"]
-
-    # Enable GUI when booting the virtual machine.
-    vb.gui = true
-
+  config.vm.provider "vmware_fusion" do |vb|
+    # Disable GUI when booting the virtual machine.
+    vb.gui = false
+  
     # Allocate memory to the virtual machine.
-    vb.memory = "4096"
+    vb.memory = "2048"
 
     # Allocate processors to the virtual machine.
-    vb.cpus = "2"
-
-    # Set name for the virtual machine.
-    vb.name = "sloopstash-ubuntu-desktop"
+    vb.cpus = "1"
   end
   #
   # View the documentation for the provider you are using for more
@@ -87,12 +81,5 @@ Vagrant.configure("2") do |config|
     apt update
     apt upgrade -y
     apt install -y wget vim net-tools gcc make tar git unzip sysstat tree
-    wget https://dl.google.com/linux/direct/google-chrome-stable_current_amd64.deb --quiet
-    apt install -y ./google-chrome-stable_current_amd64.deb
-    rm google-chrome-stable_current_amd64.deb
-    wget -qO - https://download.sublimetext.com/sublimehq-pub.gpg | sudo apt-key add -
-    echo "deb https://download.sublimetext.com/ apt/stable/" | sudo tee /etc/apt/sources.list.d/sublime-text.list
-    apt update
-    apt install -y sublime-text
   SHELL
 end

--- a/vagrant/ubuntu-22-04-server/vmware/arm64/Vagrantfile
+++ b/vagrant/ubuntu-22-04-server/vmware/arm64/Vagrantfile
@@ -1,0 +1,85 @@
+# -*- mode: ruby -*-
+# vi: set ft=ruby :
+
+# All Vagrant configuration is done below. The "2" in Vagrant.configure
+# configures the configuration version (we support older styles for
+# backwards compatibility). Please don't change it unless you know what
+# you're doing.
+Vagrant.configure("2") do |config|
+  # The most common configuration options are documented and commented below.
+  # For a complete reference, please see the online documentation at
+  # https://docs.vagrantup.com.
+
+  # Every Vagrant development environment requires a box. You can search for
+  # boxes at https://vagrantcloud.com/search.
+  config.vm.box = "sloopstash/ubuntu-22-04-server-arm64"
+
+ # Define virtual machine name.
+  config.vm.define "sloopstash-ubuntu-22-04-server"
+
+  # Set virtual machine hostname.
+  config.vm.hostname = "sloopstash-ubuntu-22-04-server"
+
+  # Disable automatic box update checking. If you disable this, then
+  # boxes will only be checked for updates when the user runs
+  # `vagrant box outdated`. This is not recommended.
+  config.vm.box_check_update = false
+
+  # Create a forwarded port mapping which allows access to a specific port
+  # within the machine from a port on the host machine. In the example below,
+  # accessing "localhost:8080" will access port 80 on the guest machine.
+  # NOTE: This will enable public access to the opened port
+  # config.vm.network "forwarded_port", guest: 443, host: 443, auto_correct: false
+
+  # Create a forwarded port mapping which allows access to a specific port
+  # within the machine from a port on the host machine and only allow access
+  # via 127.0.0.1 to disable public access
+  # config.vm.network "forwarded_port", guest: 80, host: 8080, host_ip: "127.0.0.1"
+
+  # Create a private network, which allows host-only access to the machine
+  # using a specific IP.
+  config.vm.network "private_network", ip: "192.168.2.6"
+
+  # Create a public network, which generally matched to bridged network.
+  # Bridged networks make the machine appear as another physical device on
+  # your network.
+  # config.vm.network "public_network"
+
+  # Share an additional folder to the guest VM. The first argument is
+  # the path on the host to the actual folder. The second argument is
+  # the path on the guest to mount the folder. And the optional third
+  # argument is a set of non-required options.
+  config.vm.synced_folder ".", "/vagrant", disabled: true
+
+  # SSH credentials to connect to virtual machine.
+  config.ssh.username = "vagrant"
+  config.ssh.private_key_path = ["~/.vagrant.d/insecure_private_key"]
+  config.ssh.insert_key = false
+
+  # Provider-specific configuration so you can fine-tune various
+  # backing providers for Vagrant. These expose provider-specific options.
+  # Example for VirtualBox:
+  #
+  config.vm.provider "vmware_fusion" do |vb|
+    # Disable GUI when booting the virtual machine.
+    vb.gui = false
+  
+    # Allocate memory to the virtual machine.
+    vb.memory = "2048"
+
+    # Allocate processors to the virtual machine.
+    vb.cpus = "1"
+  end
+  #
+  # View the documentation for the provider you are using for more
+  # information on available options.
+
+  # Enable provisioning with a shell script. Additional provisioners such as
+  # Puppet, Chef, Ansible, Salt, and Docker are also available. Please see the
+  # documentation for more information about their specific syntax and use.
+  config.vm.provision "shell", inline: <<-SHELL
+    apt update
+    apt upgrade -y
+    apt install -y wget vim net-tools gcc make tar git unzip sysstat tree
+  SHELL
+end


### PR DESCRIPTION
I've performed a reorganization of the directory structure, arranging the Vagrantfile based on the machine's name and its associated providers, namely Virtualbox and VMware. At present, two providers have been included in this setup. Also included Vagrantfile for builging Ubuntu 22.04 VM on Mac machine based on Apple M1/M2 chip using VMware Fusion.

The Virtualbox and VMware directories further branch into architecture-specific subdirectories, including amd64 and arm64. For a Mac machine utilizing the Apple M1/M2 chip,
the suitable Vagrantfile to employ is the arm64 variant.