### PR TITLE
Add Vagrantfile for provisioning multiple VM’s on VMware fusion

### DIFF
--- a/vagrant/alma-linux-8/vmware/amd64/server/Vagrantfile
+++ b/vagrant/alma-linux-8/vmware/amd64/server/Vagrantfile
@@ -1,0 +1,85 @@
+# -*- mode: ruby -*-
+# vi: set ft=ruby :
+
+# All Vagrant configuration is done below. The "2" in Vagrant.configure
+# configures the configuration version (we support older styles for
+# backwards compatibility). Please don't change it unless you know what
+# you're doing.
+Vagrant.configure("2") do |config|
+  # The most common configuration options are documented and commented below.
+  # For a complete reference, please see the online documentation at
+  # https://docs.vagrantup.com.
+
+  # Every Vagrant development environment requires a box. You can search for
+  # boxes at https://vagrantcloud.com/search.
+  config.vm.box = "sloopstash/alma-linux-8"
+  config.vm.box_version = "1.1.1"
+
+ # Define virtual machine name.
+  config.vm.define "sloopstash-alma-linux-8-server"
+
+  # Set virtual machine hostname.
+  config.vm.hostname = "sloopstash-alma-linux-8-server"
+
+  # Disable automatic box update checking. If you disable this, then
+  # boxes will only be checked for updates when the user runs
+  # `vagrant box outdated`. This is not recommended.
+  config.vm.box_check_update = false
+
+  # Create a forwarded port mapping which allows access to a specific port
+  # within the machine from a port on the host machine. In the example below,
+  # accessing "localhost:8080" will access port 80 on the guest machine.
+  # NOTE: This will enable public access to the opened port
+  # config.vm.network "forwarded_port", guest: 443, host: 443, auto_correct: false
+
+  # Create a forwarded port mapping which allows access to a specific port
+  # within the machine from a port on the host machine and only allow access
+  # via 127.0.0.1 to disable public access
+  # config.vm.network "forwarded_port", guest: 80, host: 8080, host_ip: "127.0.0.1"
+
+  # Create a private network, which allows host-only access to the machine
+  # using a specific IP.
+  config.vm.network "private_network", ip: "192.168.201.7"
+
+  # Create a public network, which generally matched to bridged network.
+  # Bridged networks make the machine appear as another physical device on
+  # your network.
+  # config.vm.network "public_network"
+
+  # Share an additional folder to the guest VM. The first argument is
+  # the path on the host to the actual folder. The second argument is
+  # the path on the guest to mount the folder. And the optional third
+  # argument is a set of non-required options.
+  config.vm.synced_folder ".", "/vagrant", disabled: true
+
+  # SSH credentials to connect to virtual machine.
+  config.ssh.username = "vagrant"
+  config.ssh.private_key_path = ["~/.vagrant.d/insecure_private_key"]
+  config.ssh.insert_key = false
+
+  # Provider-specific configuration so you can fine-tune various
+  # backing providers for Vagrant. These expose provider-specific options.
+  # Example for VirtualBox:
+  #
+  config.vm.provider "vmware_fusion" do |vb|
+    # Disable GUI when booting the virtual machine.
+    vb.gui = false
+  
+    # Allocate memory to the virtual machine.
+    vb.memory = "2048"
+
+    # Allocate processors to the virtual machine.
+    vb.cpus = "1"
+  end
+  #
+  # View the documentation for the provider you are using for more
+  # information on available options.
+
+  # Enable provisioning with a shell script. Additional provisioners such as
+  # Puppet, Chef, Ansible, Salt, and Docker are also available. Please see the
+  # documentation for more information about their specific syntax and use.
+ config.vm.provision "shell", inline: <<-SHELL
+    dnf update -y
+    dnf install -y wget vim net-tools initscripts gcc make tar bind-utils nc git unzip sysstat tree
+  SHELL
+end

--- a/vagrant/alma-linux-9/vmware/amd64/server/Vagrantfile
+++ b/vagrant/alma-linux-9/vmware/amd64/server/Vagrantfile
@@ -1,0 +1,85 @@
+# -*- mode: ruby -*-
+# vi: set ft=ruby :
+
+# All Vagrant configuration is done below. The "2" in Vagrant.configure
+# configures the configuration version (we support older styles for
+# backwards compatibility). Please don't change it unless you know what
+# you're doing.
+Vagrant.configure("2") do |config|
+  # The most common configuration options are documented and commented below.
+  # For a complete reference, please see the online documentation at
+  # https://docs.vagrantup.com.
+
+  # Every Vagrant development environment requires a box. You can search for
+  # boxes at https://vagrantcloud.com/search.
+  config.vm.box = "sloopstash/alma-linux-9"
+  config.vm.box_version = "1.1.1"
+
+ # Define virtual machine name.
+  config.vm.define "sloopstash-alma-linux-9-server"
+
+  # Set virtual machine hostname.
+  config.vm.hostname = "sloopstash-alma-linux-9-server"
+
+  # Disable automatic box update checking. If you disable this, then
+  # boxes will only be checked for updates when the user runs
+  # `vagrant box outdated`. This is not recommended.
+  config.vm.box_check_update = false
+
+  # Create a forwarded port mapping which allows access to a specific port
+  # within the machine from a port on the host machine. In the example below,
+  # accessing "localhost:8080" will access port 80 on the guest machine.
+  # NOTE: This will enable public access to the opened port
+  # config.vm.network "forwarded_port", guest: 443, host: 443, auto_correct: false
+
+  # Create a forwarded port mapping which allows access to a specific port
+  # within the machine from a port on the host machine and only allow access
+  # via 127.0.0.1 to disable public access
+  # config.vm.network "forwarded_port", guest: 80, host: 8080, host_ip: "127.0.0.1"
+
+  # Create a private network, which allows host-only access to the machine
+  # using a specific IP.
+  config.vm.network "private_network", ip: "192.168.201.8"
+
+  # Create a public network, which generally matched to bridged network.
+  # Bridged networks make the machine appear as another physical device on
+  # your network.
+  # config.vm.network "public_network"
+
+  # Share an additional folder to the guest VM. The first argument is
+  # the path on the host to the actual folder. The second argument is
+  # the path on the guest to mount the folder. And the optional third
+  # argument is a set of non-required options.
+  config.vm.synced_folder ".", "/vagrant", disabled: true
+
+  # SSH credentials to connect to virtual machine.
+  config.ssh.username = "vagrant"
+  config.ssh.private_key_path = ["~/.vagrant.d/insecure_private_key"]
+  config.ssh.insert_key = false
+
+  # Provider-specific configuration so you can fine-tune various
+  # backing providers for Vagrant. These expose provider-specific options.
+  # Example for VirtualBox:
+  #
+  config.vm.provider "vmware_fusion" do |vb|
+    # Disable GUI when booting the virtual machine.
+    vb.gui = false
+  
+    # Allocate memory to the virtual machine.
+    vb.memory = "2048"
+
+    # Allocate processors to the virtual machine.
+    vb.cpus = "1"
+  end
+  #
+  # View the documentation for the provider you are using for more
+  # information on available options.
+
+  # Enable provisioning with a shell script. Additional provisioners such as
+  # Puppet, Chef, Ansible, Salt, and Docker are also available. Please see the
+  # documentation for more information about their specific syntax and use.
+ config.vm.provision "shell", inline: <<-SHELL
+    dnf update -y
+    dnf install -y wget vim net-tools initscripts gcc make tar bind-utils nc git unzip sysstat tree
+  SHELL
+end

--- a/vagrant/rocky-linux-8/vmware/amd64/server/Vagrantfile
+++ b/vagrant/rocky-linux-8/vmware/amd64/server/Vagrantfile
@@ -1,0 +1,85 @@
+# -*- mode: ruby -*-
+# vi: set ft=ruby :
+
+# All Vagrant configuration is done below. The "2" in Vagrant.configure
+# configures the configuration version (we support older styles for
+# backwards compatibility). Please don't change it unless you know what
+# you're doing.
+Vagrant.configure("2") do |config|
+  # The most common configuration options are documented and commented below.
+  # For a complete reference, please see the online documentation at
+  # https://docs.vagrantup.com.
+
+  # Every Vagrant development environment requires a box. You can search for
+  # boxes at https://vagrantcloud.com/search.
+  config.vm.box = "sloopstash/rocky-linux-8"
+  config.vm.box_version = "1.1.1"
+
+ # Define virtual machine name.
+  config.vm.define "sloopstash-rocky-linux-8-server"
+
+  # Set virtual machine hostname.
+  config.vm.hostname = "sloopstash-rocky-linux-8-server"
+
+  # Disable automatic box update checking. If you disable this, then
+  # boxes will only be checked for updates when the user runs
+  # `vagrant box outdated`. This is not recommended.
+  config.vm.box_check_update = false
+
+  # Create a forwarded port mapping which allows access to a specific port
+  # within the machine from a port on the host machine. In the example below,
+  # accessing "localhost:8080" will access port 80 on the guest machine.
+  # NOTE: This will enable public access to the opened port
+  # config.vm.network "forwarded_port", guest: 443, host: 443, auto_correct: false
+
+  # Create a forwarded port mapping which allows access to a specific port
+  # within the machine from a port on the host machine and only allow access
+  # via 127.0.0.1 to disable public access
+  # config.vm.network "forwarded_port", guest: 80, host: 8080, host_ip: "127.0.0.1"
+
+  # Create a private network, which allows host-only access to the machine
+  # using a specific IP.
+  config.vm.network "private_network", ip: "192.168.201.7"
+
+  # Create a public network, which generally matched to bridged network.
+  # Bridged networks make the machine appear as another physical device on
+  # your network.
+  # config.vm.network "public_network"
+
+  # Share an additional folder to the guest VM. The first argument is
+  # the path on the host to the actual folder. The second argument is
+  # the path on the guest to mount the folder. And the optional third
+  # argument is a set of non-required options.
+  config.vm.synced_folder ".", "/vagrant", disabled: true
+
+  # SSH credentials to connect to virtual machine.
+  config.ssh.username = "vagrant"
+  config.ssh.private_key_path = ["~/.vagrant.d/insecure_private_key"]
+  config.ssh.insert_key = false
+
+  # Provider-specific configuration so you can fine-tune various
+  # backing providers for Vagrant. These expose provider-specific options.
+  # Example for VirtualBox:
+  #
+  config.vm.provider "vmware_fusion" do |vb|
+    # Disable GUI when booting the virtual machine.
+    vb.gui = false
+  
+    # Allocate memory to the virtual machine.
+    vb.memory = "2048"
+
+    # Allocate processors to the virtual machine.
+    vb.cpus = "1"
+  end
+  #
+  # View the documentation for the provider you are using for more
+  # information on available options.
+
+  # Enable provisioning with a shell script. Additional provisioners such as
+  # Puppet, Chef, Ansible, Salt, and Docker are also available. Please see the
+  # documentation for more information about their specific syntax and use.
+   config.vm.provision "shell", inline: <<-SHELL
+    dnf update -y
+    dnf install -y wget vim net-tools initscripts gcc make tar bind-utils nc git unzip sysstat tree
+  SHELL
+end

--- a/vagrant/rocky-linux-8/vmware/amd64/server/Vagrantfile
+++ b/vagrant/rocky-linux-8/vmware/amd64/server/Vagrantfile
@@ -39,7 +39,7 @@ Vagrant.configure("2") do |config|
 
   # Create a private network, which allows host-only access to the machine
   # using a specific IP.
-  config.vm.network "private_network", ip: "192.168.201.7"
+  config.vm.network "private_network", ip: "192.168.201.9"
 
   # Create a public network, which generally matched to bridged network.
   # Bridged networks make the machine appear as another physical device on

--- a/vagrant/rocky-linux-9/vmware/amd64/server/Vagrantfile
+++ b/vagrant/rocky-linux-9/vmware/amd64/server/Vagrantfile
@@ -79,7 +79,7 @@ Vagrant.configure("2") do |config|
   # Puppet, Chef, Ansible, Salt, and Docker are also available. Please see the
   # documentation for more information about their specific syntax and use.
    config.vm.provision "shell", inline: <<-SHELL
-    dnf update -y
+   dnf update -y
     dnf install -y wget vim net-tools initscripts gcc make tar bind-utils nc git unzip sysstat tree
   SHELL
 end

--- a/vagrant/rocky-linux-9/vmware/amd64/server/Vagrantfile
+++ b/vagrant/rocky-linux-9/vmware/amd64/server/Vagrantfile
@@ -1,0 +1,85 @@
+# -*- mode: ruby -*-
+# vi: set ft=ruby :
+
+# All Vagrant configuration is done below. The "2" in Vagrant.configure
+# configures the configuration version (we support older styles for
+# backwards compatibility). Please don't change it unless you know what
+# you're doing.
+Vagrant.configure("2") do |config|
+  # The most common configuration options are documented and commented below.
+  # For a complete reference, please see the online documentation at
+  # https://docs.vagrantup.com.
+
+  # Every Vagrant development environment requires a box. You can search for
+  # boxes at https://vagrantcloud.com/search.
+  config.vm.box = "sloopstash/rocky-linux-9"
+  config.vm.box_version = "1.1.1"
+
+ # Define virtual machine name.
+  config.vm.define "sloopstash-rocky-linux-9-server"
+
+  # Set virtual machine hostname.
+  config.vm.hostname = "sloopstash-rocky-linux-9-server"
+
+  # Disable automatic box update checking. If you disable this, then
+  # boxes will only be checked for updates when the user runs
+  # `vagrant box outdated`. This is not recommended.
+  config.vm.box_check_update = false
+
+  # Create a forwarded port mapping which allows access to a specific port
+  # within the machine from a port on the host machine. In the example below,
+  # accessing "localhost:8080" will access port 80 on the guest machine.
+  # NOTE: This will enable public access to the opened port
+  # config.vm.network "forwarded_port", guest: 443, host: 443, auto_correct: false
+
+  # Create a forwarded port mapping which allows access to a specific port
+  # within the machine from a port on the host machine and only allow access
+  # via 127.0.0.1 to disable public access
+  # config.vm.network "forwarded_port", guest: 80, host: 8080, host_ip: "127.0.0.1"
+
+  # Create a private network, which allows host-only access to the machine
+  # using a specific IP.
+  config.vm.network "private_network", ip: "192.168.201.10"
+
+  # Create a public network, which generally matched to bridged network.
+  # Bridged networks make the machine appear as another physical device on
+  # your network.
+  # config.vm.network "public_network"
+
+  # Share an additional folder to the guest VM. The first argument is
+  # the path on the host to the actual folder. The second argument is
+  # the path on the guest to mount the folder. And the optional third
+  # argument is a set of non-required options.
+  config.vm.synced_folder ".", "/vagrant", disabled: true
+
+  # SSH credentials to connect to virtual machine.
+  config.ssh.username = "vagrant"
+  config.ssh.private_key_path = ["~/.vagrant.d/insecure_private_key"]
+  config.ssh.insert_key = false
+
+  # Provider-specific configuration so you can fine-tune various
+  # backing providers for Vagrant. These expose provider-specific options.
+  # Example for VirtualBox:
+  #
+  config.vm.provider "vmware_fusion" do |vb|
+    # Disable GUI when booting the virtual machine.
+    vb.gui = false
+  
+    # Allocate memory to the virtual machine.
+    vb.memory = "2048"
+
+    # Allocate processors to the virtual machine.
+    vb.cpus = "1"
+  end
+  #
+  # View the documentation for the provider you are using for more
+  # information on available options.
+
+  # Enable provisioning with a shell script. Additional provisioners such as
+  # Puppet, Chef, Ansible, Salt, and Docker are also available. Please see the
+  # documentation for more information about their specific syntax and use.
+   config.vm.provision "shell", inline: <<-SHELL
+    dnf update -y
+    dnf install -y wget vim net-tools initscripts gcc make tar bind-utils nc git unzip sysstat tree
+  SHELL
+end


### PR DESCRIPTION
This commit introduces a new Vagrantfile to the project. The Vagrantfile is used for provisioning a Alma Linux 8/9, Rocky Linux 8/9 virtual machine in the VMware fusion hypervisor.